### PR TITLE
Altera configuração de boxes para uso de proxy se necessário

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Este projeto foi testado com boxes CentOS 7.
 * Vagrant >= 1.8
   * plugin vagrant-hostsupdater (atua no host)
   * plugin vagrant-hosts (atua no guest)
+  * plugin vagrant-proxyconf (caso necessite e esteja atrás de proxy)
 * Box gutocarvalho/centos7x64
 
 Você precisa ter pelo menos 4 GB de RAM livre para subir as VMs.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,10 +5,20 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
+  # configura proxy se necessário e o plugin estiver instalado
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    #vagrant plugin install vagrant-proxyconf (check https://tmatilai.github.io/vagrant-proxyconf/)
+    config.proxy.http     = "http://10.122.19.54:5865"
+    config.proxy.https    = "http://10.122.19.54:5865"
+    config.proxy.no_proxy = "localhost, 127.0.0.1, .hacklab"
+  end
+
+  # box para todas as VM
+  config.vm.box = "gutocarvalho/centos7x64"
+
   # puppet server + puppet agent
   config.vm.define "puppetserver" do |puppetserver|
     puppetserver.vm.hostname = "puppetserver.hacklab"
-    puppetserver.vm.box = "gutocarvalho/centos7x64"
     puppetserver.vm.network :private_network, ip: "192.168.250.20"
     puppetserver.vm.provision "shell", path: "puppet/instala.sh"
     puppetserver.vm.provision :hosts do |provisioner|
@@ -24,7 +34,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # puppet agent + puppetdb + puppet explorer
   config.vm.define "puppetdb" do |puppetdb|
     puppetdb.vm.hostname = "puppetdb.hacklab"
-    puppetdb.vm.box = "gutocarvalho/centos7x64"
     puppetdb.vm.network :private_network, ip: "192.168.250.25"
     puppetdb.vm.provider "virtualbox" do |v|
       v.customize [ "modifyvm", :id, "--cpus", "2" ]
@@ -45,7 +54,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #  puppet agent + mcollective client + activemq
   config.vm.define "puppetmq" do |puppetmq|
     puppetmq.vm.hostname = "puppetmq.hacklab"
-    puppetmq.vm.box = "gutocarvalho/centos7x64"
     puppetmq.vm.network :private_network, ip: "192.168.250.30"
     puppetmq.vm.provider "virtualbox" do |v|
       v.customize [ "modifyvm", :id, "--cpus", "2" ]


### PR DESCRIPTION
- verifica se plugin vagrant-proxyconf está instalado e faz uso de proxy
- configura box única como padrão para as VM